### PR TITLE
Add `Image` component based off the one from vtex.store-components

### DIFF
--- a/.github/PULL_REQUEST_TEMPLATE.md
+++ b/.github/PULL_REQUEST_TEMPLATE.md
@@ -1,23 +1,11 @@
-#### What did you change? \*
-
-<!--- Describe your changes in detail. -->
-
-#### Why? \*
-
-<!--- What is the motivation and context for this change? -->
+#### What does this PR do? \*
 
 #### How to test it? \*
 
-<!--- Link to a running workspace with some steps to reproduce it or even a screenshot of before/after -->
+#### Describe alternatives you've considered, if any. \*
 
-#### Related to / Depends on?
+<!--- Optional -->
 
-<!--- Link to an issue or clubhouse task that did motivate this PR or even others PRs that this one depends. -->
+#### Related to / Depends on \*
 
-#### Types of changes \*
-
-- [ ] Bug fix (a non-breaking change which fixes an issue)
-- [ ] New feature (a non-breaking change which adds functionality)
-- [ ] Breaking change (fix or feature that would cause existing functionality to change)
-- [ ] Technical improvements
-  <!--- * Required -->
+<!--- Optional -->

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -6,4 +6,6 @@ The format is based on [Keep a Changelog](http://keepachangelog.com/en/1.0.0/)
 and this project adheres to [Semantic Versioning](http://semver.org/spec/v2.0.0.html).
 
 ## [Unreleased]
-
+### Added
+- Initial implementation.
+- Port `Image` component from `vtex.store-components`.

--- a/manifest.json
+++ b/manifest.json
@@ -1,8 +1,8 @@
 {
   "vendor": "vtex",
-  "name": "image",
+  "name": "store-images",
   "version": "0.0.0",
-  "title": "VTEX Image",
+  "title": "VTEX Store Images",
   "description": "Set of VTEX components to handle images",
   "builders": {
     "react": "3.x",

--- a/manifest.json
+++ b/manifest.json
@@ -6,10 +6,13 @@
   "description": "Set of VTEX components to handle images",
   "builders": {
     "react": "3.x",
+    "store": "0.x",
     "messages": "1.x",
     "docs": "0.x"
   },
-  "dependencies": {},
+  "dependencies": {
+    "vtex.native-types": "0.x"
+  },
   "registries": ["smartcheckout"],
   "policies": [],
   "$schema": "https://raw.githubusercontent.com/vtex/node-vtex-api/master/gen/manifest.schema"

--- a/manifest.json
+++ b/manifest.json
@@ -1,6 +1,6 @@
 {
   "vendor": "vtex",
-  "name": "store-images",
+  "name": "store-image",
   "version": "0.0.0",
   "title": "VTEX Store Images",
   "description": "Set of VTEX components to handle images",

--- a/messages/en.json
+++ b/messages/en.json
@@ -1,4 +1,8 @@
 {
-  "admin/test": "test",
-  "store/test": "test"
+  "admin/editor.image.title": "Image",
+  "admin/editor.image.description": "Show any image",
+  "admin/editor.image.src.title": "Image",
+  "admin/editor.image.alt.title": "Alternative text",
+  "admin/editor.blockClass.title": "CSS Block Class",
+  "admin/editor.blockClass.description": "Adds an extra class name to ease styling"
 }

--- a/messages/es.json
+++ b/messages/es.json
@@ -1,4 +1,8 @@
 {
-  "admin/test": "teste",
-  "store/test": "teste"
+  "admin/editor.image.title": "Imagen",
+  "admin/editor.image.description": "Mostrar cualquier imagen",
+  "admin/editor.image.src.title": "Imagen",
+  "admin/editor.image.alt.title": "Texto alternativo",
+  "admin/editor.blockClass.title": "CSS Block Class",
+  "admin/editor.blockClass.description": "Agrega un nombre de clase extra para facilitar la estilización"
 }

--- a/messages/pt.json
+++ b/messages/pt.json
@@ -1,4 +1,8 @@
 {
-  "admin/test": "teste",
-  "store/test": "teste"
+  "admin/editor.image.title": "Imagem",
+  "admin/editor.image.description": "Exiba qualquer imagem",
+  "admin/editor.image.src.title": "Imagem",
+  "admin/editor.image.alt.title": "Texto alternativo",
+  "admin/editor.blockClass.title": "CSS Block Class",
+  "admin/editor.blockClass.description": "Adiciona um nome de classe extra para facilitar a estilização"
 }

--- a/react/Image.tsx
+++ b/react/Image.tsx
@@ -1,0 +1,98 @@
+import React, { ImgHTMLAttributes, Fragment } from 'react'
+import { generateBlockClass } from '@vtex/css-handles'
+import { injectIntl, InjectedIntl, defineMessages } from 'react-intl'
+import { formatIOMessage } from 'vtex.native-types'
+
+import styles from './styles.css'
+
+interface ImageProps extends ImgHTMLAttributes<HTMLImageElement> {
+  maxWidth: string
+  maxHeight: string
+  blockClass: string
+  link: {
+    url: string
+    noFollow: boolean
+    openNewTab: boolean
+    title: string
+  }
+  intl: InjectedIntl
+}
+
+const Image: StorefrontFunctionComponent<ImageProps> = ({
+  src,
+  alt = '',
+  maxWidth = 'none',
+  maxHeight = 'none',
+  srcSet = '',
+  sizes = '',
+  blockClass,
+  link,
+  intl,
+}) => {
+  const classes = generateBlockClass(styles.imageElement, blockClass)
+  const maxDimensions = {
+    maxWidth: maxWidth,
+    maxHeight: maxHeight,
+  }
+
+  const formattedSrc = formatIOMessage({ id: src, intl })
+  const formattedAlt = formatIOMessage({ id: alt, intl })
+
+  const imgElement = (
+    <img
+      src={formattedSrc}
+      srcSet={srcSet}
+      sizes={sizes}
+      alt={formattedAlt}
+      style={maxDimensions}
+      className={classes}
+    />
+  )
+
+  return link ? (
+    <a
+      href={formatIOMessage({ id: link.url, intl })}
+      rel={link.noFollow ? 'nofollow' : ''}
+      target={link.openNewTab ? '_blank' : ''}
+      title={formatIOMessage({ id: link.title, intl })}>
+      {imgElement}
+    </a>
+  ) : (
+    <Fragment>{imgElement}</Fragment>
+  )
+}
+
+const messages = defineMessages({
+  title: {
+    defaultMessage: '',
+    id: 'admin/editor.image.title',
+  },
+  description: {
+    defaultMessage: '',
+    id: 'admin/editor.image.description',
+  },
+  blockClassTitle: {
+    defaultMessage: '',
+    id: 'admin/editor.blockClass.title',
+  },
+  blockClassDescription: {
+    defaultMessage: '',
+    id: 'admin/editor.blockClass.description',
+  },
+})
+
+Image.schema = {
+  title: messages.title,
+  description: messages.description,
+  type: 'object',
+  properties: {
+    blockClass: {
+      title: 'admin/editor.blockClass.title',
+      description: 'admin/editor.blockClass.description',
+      type: 'string',
+      isLayout: true,
+    },
+  },
+}
+
+export default injectIntl(Image)

--- a/react/Image.tsx
+++ b/react/Image.tsx
@@ -5,7 +5,7 @@ import { formatIOMessage } from 'vtex.native-types'
 
 import styles from './styles.css'
 
-interface ImageProps extends ImgHTMLAttributes<HTMLImageElement> {
+export interface ImageProps extends ImgHTMLAttributes<HTMLImageElement> {
   maxWidth: string
   maxHeight: string
   blockClass: string
@@ -82,13 +82,13 @@ const messages = defineMessages({
 })
 
 Image.schema = {
-  title: messages.title,
-  description: messages.description,
+  title: messages.title.id,
+  description: messages.description.id,
   type: 'object',
   properties: {
     blockClass: {
-      title: 'admin/editor.blockClass.title',
-      description: 'admin/editor.blockClass.description',
+      title: messages.blockClassTitle.id,
+      description: messages.blockClassDescription.id,
       type: 'string',
       isLayout: true,
     },

--- a/react/package.json
+++ b/react/package.json
@@ -4,6 +4,7 @@
     "test": "vtex-test-tools test"
   },
   "dependencies": {
+    "@vtex/css-handles": "^1.1.3",
     "apollo-client": "^2.6.3",
     "react": "^16.8.6",
     "react-apollo": "^2.5.8",

--- a/react/styles.css
+++ b/react/styles.css
@@ -1,0 +1,2 @@
+.imageElement {
+}

--- a/react/typings/css.d.ts
+++ b/react/typings/css.d.ts
@@ -1,0 +1,8 @@
+declare module '*.css' {
+  const css: CSSHandles
+  export default css
+}
+
+interface CSSHandles {
+  imageElement: string
+}

--- a/react/typings/global.d.ts
+++ b/react/typings/global.d.ts
@@ -1,0 +1,8 @@
+import { FunctionComponent } from 'react'
+
+declare global {
+  interface StorefrontFunctionComponent<P = {}> extends FunctionComponent<P> {
+    schema?: object
+    getSchema?(props?: P): object
+  }
+}

--- a/react/typings/vtex.native-types.d.ts
+++ b/react/typings/vtex.native-types.d.ts
@@ -1,0 +1,1 @@
+declare module 'vtex.native-types'

--- a/react/yarn.lock
+++ b/react/yarn.lock
@@ -1084,6 +1084,11 @@
     lodash.unescape "4.0.1"
     semver "5.5.0"
 
+"@vtex/css-handles@^1.1.3":
+  version "1.1.3"
+  resolved "https://registry.yarnpkg.com/@vtex/css-handles/-/css-handles-1.1.3.tgz#30bd1010f2907443188738f74dd11d3b6b4ac624"
+  integrity sha512-DkqnzMf5jW6lQ1L8wYb9fnXyh0FqZym8qEokGYjeLUqBLBAiVK8XbI4U0ezFswWTOJ3iHZUkUjqPt5WodxR29w==
+
 "@vtex/test-tools@^0.3.2":
   version "0.3.2"
   resolved "https://registry.yarnpkg.com/@vtex/test-tools/-/test-tools-0.3.2.tgz#f9423c98f1960b226d18dfe59d6d9c430e14d530"

--- a/store/contentSchemas.json
+++ b/store/contentSchemas.json
@@ -1,0 +1,22 @@
+{
+  "definitions": {
+    "ImageNew": {
+      "properties": {
+        "src": {
+          "title": "admin/editor.image.src.title",
+          "$ref": "app:vtex.native-types#/definitions/url",
+          "default": ""
+        },
+        "link": {
+          "$ref": "app:vtex.native-types#/definitions/link",
+          "default": ""
+        },
+        "alt": {
+          "title": "admin/editor.image.alt.title",
+          "$ref": "app:vtex.native-types#/definitions/text",
+          "default": ""
+        }
+      }
+    }
+  }
+}

--- a/store/contentSchemas.json
+++ b/store/contentSchemas.json
@@ -1,6 +1,6 @@
 {
   "definitions": {
-    "ImageNew": {
+    "Image": {
       "properties": {
         "src": {
           "title": "admin/editor.image.src.title",

--- a/store/interfaces.json
+++ b/store/interfaces.json
@@ -1,8 +1,8 @@
 {
-  "image-new": {
+  "image": {
     "component": "Image",
     "content": {
-      "$ref": "app:vtex.image#/definitions/ImageNew"
+      "$ref": "app:vtex.store-image#/definitions/ImageNew"
     }
   }
 }

--- a/store/interfaces.json
+++ b/store/interfaces.json
@@ -1,5 +1,8 @@
 {
   "image-new": {
-    "component": "Image"
+    "component": "Image",
+    "content": {
+      "$ref": "app:vtex.image#/definitions/ImageNew"
+    }
   }
 }

--- a/store/interfaces.json
+++ b/store/interfaces.json
@@ -1,0 +1,5 @@
+{
+  "image-new": {
+    "component": "Image"
+  }
+}

--- a/store/interfaces.json
+++ b/store/interfaces.json
@@ -1,8 +1,8 @@
 {
-  "image": {
+  "image-new": {
     "component": "Image",
     "content": {
-      "$ref": "app:vtex.store-image#/definitions/ImageNew"
+      "$ref": "app:vtex.store-image#/definitions/Image"
     }
   }
 }


### PR DESCRIPTION
#### What did you change? \*

- Bring over from store-components the `Image` component, converting it to TypeScript.
- Define a new interface `image-new` that should soon be renamed to `image` when we can make `store-components` use it.
- Add type definitions and messages for the Site Editor.

#### How to test it? \*

You can see it in the Site Editor here: https://victorhmp--storecomponents.myvtex.com/admin/cms/site-editor
Or the actual component being rendered here: https://victorhmp--storecomponents.myvtex.com/about-us

#### Types of changes \*

- [ ] Bug fix (a non-breaking change which fixes an issue)
- [x] New feature (a non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)
- [x] Technical improvements
  <!--- * Required -->
