### PR TITLE
Add `image-uploader` widget to Image schema definition

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -6,6 +6,8 @@ The format is based on [Keep a Changelog](http://keepachangelog.com/en/1.0.0/)
 and this project adheres to [Semantic Versioning](http://semver.org/spec/v2.0.0.html).
 
 ## [Unreleased]
+### Added
+- `image-uploader` widget to `Image` contentSchema.
 
 ## [0.2.1] - 2019-10-24
 

--- a/store/contentSchemas.json
+++ b/store/contentSchemas.json
@@ -5,7 +5,10 @@
         "src": {
           "title": "admin/editor.image.src.title",
           "$ref": "app:vtex.native-types#/definitions/url",
-          "default": ""
+          "default": "",
+          "widget": {
+            "ui:widget": "image-uploader"
+          }
         },
         "link": {
           "$ref": "app:vtex.native-types#/definitions/link",


### PR DESCRIPTION
#### What does this PR do?

Add `image-uploader` widget to Image schema definition.

#### How to test it?

Try to upload a new image at: <https://storeimage--storecomponents.myvtex.com/admin/cms/site-editor/about-us>
