### PR TITLE
Remove description from new-image schema to remove the block from the new cms

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -6,6 +6,8 @@ The format is based on [Keep a Changelog](http://keepachangelog.com/en/1.0.0/)
 and this project adheres to [Semantic Versioning](http://semver.org/spec/v2.0.0.html).
 
 ## [Unreleased]
+### Removed
+- Remove description of `new-image` schema to make it not available in the new CMS.
 
 ## [0.5.2] - 2020-09-15
 ### Fixed

--- a/messages/en.json
+++ b/messages/en.json
@@ -1,6 +1,5 @@
 {
   "admin/editor.store-image.title": "Image",
-  "admin/editor.store-image.description": "Show any image",
   "admin/editor.store-image.src.title": "Image",
   "admin/editor.store-image.alt.title": "Alternative text",
   "admin/editor.store-image.title.title": "Image title",

--- a/messages/es.json
+++ b/messages/es.json
@@ -1,6 +1,5 @@
 {
   "admin/editor.store-image.title": "Imagen",
-  "admin/editor.store-image.description": "Mostrar cualquier imagen",
   "admin/editor.store-image.src.title": "Imagen",
   "admin/editor.store-image.alt.title": "Texto alternativo",
   "admin/editor.store-image.title.title": "Título de la imagen",

--- a/messages/pt.json
+++ b/messages/pt.json
@@ -1,6 +1,5 @@
 {
   "admin/editor.store-image.title": "Imagem",
-  "admin/editor.store-image.description": "Exiba qualquer imagem",
   "admin/editor.store-image.src.title": "Imagem",
   "admin/editor.store-image.alt.title": "Texto alternativo",
   "admin/editor.store-image.title.title": "Título da imagem",

--- a/react/Image.tsx
+++ b/react/Image.tsx
@@ -146,9 +146,6 @@ const messages = defineMessages({
   title: {
     id: 'admin/editor.store-image.title',
   },
-  description: {
-    id: 'admin/editor.store-image.description',
-  },
 })
 
 Image.schema = {

--- a/store/contentSchemas.json
+++ b/store/contentSchemas.json
@@ -2,7 +2,6 @@
   "definitions": {
     "Image": {
       "title": "admin/editor.store-image.title",
-      "description": "admin/editor.store-image.description",
       "properties": {
         "src": {
           "title": "admin/editor.image.src.title",


### PR DESCRIPTION
#### What problem is this solving?

This component is a base component of the store framework and should not appear in the new cms, since it doesn't have a container around it.

#### How to test it?

<!--- Don't forget to add a link to a Workspace where this branch is linked -->

[Workspace](https://demo--marinbrasil.myvtex.com/)

#### Screenshots or example usage:

<!--- Add some images or gifs to showcase changes in behaviour or layout. Example: before and after images -->

#### Describe alternatives you've considered, if any.

<!--- Optional -->

#### Related to / Depends on

<!--- Optional -->

#### How does this PR make you feel? [:link:](http://giphy.com/)

<!-- Go to http://giphy.com/ and pick a gif that represents how this PR makes you feel -->

![](https://media.giphy.com/media/pHWPC1N5IZGVTfRgsN/giphy.gif)
