### PR TITLE
fix: adding height as editable num field in site editor

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,6 +7,9 @@ and this project adheres to [Semantic Versioning](http://semver.org/spec/v2.0.0.
 
 ## [Unreleased]
 
+### Fix
+- `Height` not apearing in site editor and fixed to be a number instead of enum
+
 ## [0.9.0] - 2021-01-29
 ### Added
 - Exports CSS Handles embedded within `Image` component.

--- a/react/modules/schema.ts
+++ b/react/modules/schema.ts
@@ -68,8 +68,7 @@ export const IMAGE_LIST_SCHEMA = {
   properties: {
     height: {
       default: 420,
-      enum: [420, 440],
-      isLayout: true,
+      isLayout: false,
       title: IMAGE_LIST_MESSAGES.heightTitle.id,
       type: 'number',
     },


### PR DESCRIPTION
#### What problem is this solving?

Include height as editable num field in site editor for image-list

#### How to test it?

Go to site editor, find for image list block and try to edit

[Workspace](https://iespinoza--arcaplanet.myvtex.com/admin/cms/site-editor)

#### Screenshots or example usage:

![image](https://user-images.githubusercontent.com/13649073/106780977-4e660a80-6627-11eb-94ee-1abd70ea2502.png)

#### How does this PR make you feel? [:link:](http://giphy.com/)

![](https://media.giphy.com/media/xT5LMCfQTR4rabzdE4/giphy.gif)
