### PR TITLE
feat: adding inline size attributes

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,11 +7,12 @@ and this project adheres to [Semantic Versioning](http://semver.org/spec/v2.0.0.
 
 ## [Unreleased]
 
+### Added 
+- `inlineWidth` and `inlineHeight` props to `Image` component.
+
 ## [0.10.0] - 2021-03-03
 
-
 ### Added
-
 - I18n Ro and JP.
 - Crowdin configuration file.
 

--- a/react/Image.tsx
+++ b/react/Image.tsx
@@ -14,6 +14,10 @@ const CSS_HANDLES = ['imageElement', 'imageElementLink'] as const
 export interface ImageProps
   extends ImageSchema,
     ImgHTMLAttributes<HTMLImageElement> {
+  width?: string | number,
+  height?: string | number,
+  inlineWidth?: string | number,
+  inlineHeight?: string | number,
   maxWidth?: string | number
   maxHeight?: string | number
   minWidth?: string | number
@@ -70,6 +74,8 @@ function Image(props: ImageProps) {
     minHeight,
     width,
     height,
+    inlineWidth,
+    inlineHeight,
     srcSet = '',
     sizes = '',
     link,
@@ -109,6 +115,8 @@ function Image(props: ImageProps) {
 
   const imgElement = (
     <img
+      width={inlineWidth}
+      height={inlineHeight}
       title={title}
       sizes={sizes}
       srcSet={srcSet}

--- a/react/Image.tsx
+++ b/react/Image.tsx
@@ -14,10 +14,10 @@ const CSS_HANDLES = ['imageElement', 'imageElementLink'] as const
 export interface ImageProps
   extends ImageSchema,
     ImgHTMLAttributes<HTMLImageElement> {
-  width?: string | number,
-  height?: string | number,
-  inlineWidth?: string | number,
-  inlineHeight?: string | number,
+  width?: string | number
+  height?: string | number
+  inlineWidth?: string | number
+  inlineHeight?: string | number
   maxWidth?: string | number
   maxHeight?: string | number
   minWidth?: string | number


### PR DESCRIPTION
#### What problem is this solving?

A common good practice in images is to specify their size through attributes, this PR adds two new props: `inlineWidth` and `inlineHeight` for this purpose.

#### How to test it?

[Workspace](https://imagessizeattribute--tokstokio.myvtex.com/)

#### Screenshots or example usage:

![image](https://user-images.githubusercontent.com/55160541/112478203-8699e780-8d52-11eb-85e7-8bc24e1b3e4b.png)

![image](https://user-images.githubusercontent.com/55160541/112478063-5a7e6680-8d52-11eb-88d4-f256a0fdb80e.png)

#### Related to / Depends on

[Updated docs](https://github.com/vtex-apps/store-components/pull/927)

#### How does this PR make you feel? [:link:](http://giphy.com/)

![](https://media.giphy.com/media/9058ZMj6ooluP4UUPl/giphy.gif)
