### PR TITLE
Toggle button for tablet Images

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -6,6 +6,8 @@ The format is based on [Keep a Changelog](http://keepachangelog.com/en/1.0.0/)
 and this project adheres to [Semantic Versioning](http://semver.org/spec/v2.0.0.html).
 
 ## [Unreleased]
+### Added
+- Toggle button for tablet Images
 
 ## [0.10.0] - 2021-03-03
 

--- a/docs/README.md
+++ b/docs/README.md
@@ -64,6 +64,7 @@ Note that the `slider-layout` block, exported from the Slider Layout app, is giv
 | --------- | -------- | ------------------------------------------------------------- | ------------- |
 | `images`  | `array`  | Array of objects declaring all desired images to be rendered. | `undefined`   |
 | `height`  | `number` | Image height for all images declared in the `image` object (in `px`).   | `undefined`   |
+| `useDesktopImage`  | `boolean` | Defines which image the `tablet` will inherit (`mobile` or `desktop`) | `false`   |
 
 ### `image-list` props
 
@@ -71,6 +72,7 @@ Note that the `slider-layout` block, exported from the Slider Layout app, is giv
 | --------- | -------- | ------------------------------------------------------------- | ------------- |
 | `images`  | `array`  | Array of objects declaring all desired images to be rendered. | `undefined`   |
 | `height`  | `number` | Image height for all images declared in the `image` object (in `px`).   | `undefined`   |
+| `useDesktopImage`  | `boolean` | Defines which image the `tablet` will inherit (`mobile` or `desktop`) | `false`   |
 
 - **`images` array:**
 
@@ -107,6 +109,12 @@ Thanks goes to these wonderful people ([emoji key](https://allcontributors.org/d
 <!-- ALL-CONTRIBUTORS-LIST:START - Do not remove or modify this section -->
 <!-- prettier-ignore-start -->
 <!-- markdownlint-disable -->
+<table>
+  <tr>
+    <td align="center"><a href="https://github.com/gabrielkerchner"><img src="https://avatars.githubusercontent.com/u/38087734?v=4" width="100px;" alt="Gabriel Kerchner"/><br /><sub><b>Gabriel Kerchner</b></sub></a><br /><a href="" title="Code">💻</a></td>
+  </tr>
+</table>
+
 <!-- markdownlint-enable -->
 <!-- prettier-ignore-end -->
 

--- a/react/ImageList.tsx
+++ b/react/ImageList.tsx
@@ -10,17 +10,21 @@ import type { ImagesSchema } from './ImageTypes'
 export interface ImageListProps {
   images: ImagesSchema
   height?: number
+  useDesktopImage?: boolean
 }
 
 function ImageList({
   images,
   height = 420,
+  useDesktopImage = false,
   children,
 }: PropsWithChildren<ImageListProps>) {
   const list = useListContext()?.list ?? []
-  const { isMobile } = useDevice()
+  const { isMobile, device } = useDevice()
 
-  const imageListContent = getImagesAsJSXList(images, isMobile, height)
+  const isTablet = device === "tablet"
+
+  const imageListContent = getImagesAsJSXList(images, isMobile, useDesktopImage, isTablet, height)
   const newListContextValue = list.concat(imageListContent)
 
   return (

--- a/react/ImageListWithoutContext.tsx
+++ b/react/ImageListWithoutContext.tsx
@@ -6,10 +6,13 @@ import { getImagesAsJSXList } from './modules/imageAsList'
 import type { ImageListProps } from './ImageList'
 
 const ImageListWithoutContext = (props: ImageListProps) => {
-  const { images, height = 420 } = props
-  const { isMobile } = useDevice()
+  const { images, height = 420, useDesktopImage = false } = props
 
-  const imageListContent = getImagesAsJSXList(images, isMobile, height)
+  const { isMobile, device } = useDevice()
+
+  const isTablet = device === "tablet"
+
+  const imageListContent = getImagesAsJSXList(images, isMobile, useDesktopImage, isTablet, height)
 
   return <React.Fragment>{imageListContent}</React.Fragment>
 }

--- a/react/modules/imageAsList.tsx
+++ b/react/modules/imageAsList.tsx
@@ -6,6 +6,8 @@ import type { ImagesSchema } from '../ImageTypes'
 export const getImagesAsJSXList = (
   images: ImagesSchema,
   isMobile: boolean,
+  useDesktopImage: boolean,
+  isTablet: boolean,
   height: string | number
 ) => {
   return images.map(
@@ -22,7 +24,7 @@ export const getImagesAsJSXList = (
     ) => (
       <Image
         key={idx}
-        src={isMobile && mobileImage ? mobileImage : image}
+        src={(isTablet && useDesktopImage ? image : isMobile && mobileImage ? mobileImage : image)}
         alt={description}
         maxHeight={height}
         width={width}

--- a/react/modules/schema.ts
+++ b/react/modules/schema.ts
@@ -72,5 +72,10 @@ export const IMAGE_LIST_SCHEMA = {
       title: IMAGE_LIST_MESSAGES.heightTitle.id,
       type: 'number',
     },
+    useDesktopImage: {
+      title: 'Use Desktop Image for Tablet?',
+      type: 'boolean',
+      default: false,
+    },
   },
 }


### PR DESCRIPTION
#### What problem is this solving?
The purpose of this PR is instead of the ` tablet versions` always using the `mobile image as a default`, to be able to use the `desktop image as an option` as well. Thus being able to adapt exactly to what the customer wants. 😄 

#### How to test it?

1. Go to [Workspace](https://icp821--tiendasyaco.myvtex.com/cervezas/)
2. Entry in "Inspect" , click in "Toggle Device toolbar" and use the sizes of tablet
3. You can change it via [Site Editor](https://icp821--tiendasyaco.myvtex.com/admin/cms/site-editor/cervezas) too (Screenshots below) 

#### Screenshots or example usage:

- Site Editor Input:
![image](https://user-images.githubusercontent.com/38087734/113590276-d4430980-9608-11eb-8ded-c035a41aa0c6.png)

- Expected Result with toggle true (using Desktop Image:
![image](https://user-images.githubusercontent.com/38087734/113590391-f89ee600-9608-11eb-914d-926b9fc6aa31.png)

- Expected Result when toggle is false (Using Mobile Image):
![image](https://user-images.githubusercontent.com/38087734/113590511-21bf7680-9609-11eb-9120-859a6ee35081.png)


#### How does this PR make you feel? [:link:](http://giphy.com/)

<!-- Go to http://giphy.com/ and pick a gif that represents how this PR makes you feel -->

![](https://media.giphy.com/media/5VKbvrjxpVJCM/giphy.gif)
