### PR TITLE
Feature/image preload

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -6,6 +6,9 @@ The format is based on [Keep a Changelog](http://keepachangelog.com/en/1.0.0/)
 and this project adheres to [Semantic Versioning](http://semver.org/spec/v2.0.0.html).
 
 ## [Unreleased]
+### Added
+
+- Allows preloading.
 
 ## [0.11.0] - 2021-05-05
 

--- a/docs/README.md
+++ b/docs/README.md
@@ -30,6 +30,7 @@ You are now able to use the `list-context.image-list` block, exported by the Sto
   "list-context.image-list#demo": {
     "children": ["slider-layout#demo-images"],
     "props": {
+      "preload": true,
       "height": 650,
       "images": [
         {
@@ -64,6 +65,7 @@ Note that the `slider-layout` block, exported from the Slider Layout app, is giv
 | --------- | -------- | ------------------------------------------------------------- | ------------- |
 | `images`  | `array`  | Array of objects declaring all desired images to be rendered. | `undefined`   |
 | `height`  | `number` | Image height for all images declared in the `image` object (in `px`).   | `undefined`   |
+| `preload`  | `boolean` | Preloads the first image in a list, which helps prioritizing the display of images over other assets | `undefined`   |
 
 ### `image-list` props
 

--- a/docs/README.md
+++ b/docs/README.md
@@ -65,7 +65,7 @@ Note that the `slider-layout` block, exported from the Slider Layout app, is giv
 | --------- | -------- | ------------------------------------------------------------- | ------------- |
 | `images`  | `array`  | Array of objects declaring all desired images to be rendered. | `undefined`   |
 | `height`  | `number` | Image height for all images declared in the `image` object (in `px`).   | `undefined`   |
-| `preload`  | `boolean` | Preloads the first image in a list, which helps prioritizing the display of images over other assets | `undefined`   |
+| `preload`  | `boolean` | Preloads the first image in a list, which helps prioritizing the display of images over other assets | `false`   |
 
 ### `image-list` props
 

--- a/react/Image.tsx
+++ b/react/Image.tsx
@@ -21,6 +21,7 @@ export interface ImageProps
   blockClass?: string
   experimentalPreventLayoutShift?: boolean
   classes?: CssHandlesTypes.CustomClasses<typeof CSS_HANDLES>
+  preload?: boolean
 }
 
 const useImageLoad = (
@@ -80,6 +81,7 @@ function Image(props: ImageProps) {
     promotionName,
     promotionPosition,
     classes,
+    preload,
   } = props
 
   const imageRef = useRef<HTMLImageElement | null>(null)
@@ -117,6 +119,9 @@ function Image(props: ImageProps) {
       style={imageDimensions}
       ref={imageRef}
       className={handles.imageElement}
+      {...(preload ? {
+        'data-vtex-preload': 'true'
+      } : {})}
     />
   )
 

--- a/react/ImageList.tsx
+++ b/react/ImageList.tsx
@@ -10,17 +10,19 @@ import type { ImagesSchema } from './ImageTypes'
 export interface ImageListProps {
   images: ImagesSchema
   height?: number
+  preload?: boolean
 }
 
 function ImageList({
   images,
   height = 420,
   children,
+  preload,
 }: PropsWithChildren<ImageListProps>) {
   const list = useListContext()?.list ?? []
   const { isMobile } = useDevice()
 
-  const imageListContent = getImagesAsJSXList(images, isMobile, height)
+  const imageListContent = getImagesAsJSXList(images, isMobile, height, preload)
   const newListContextValue = list.concat(imageListContent)
 
   return (

--- a/react/ImageSlider.tsx
+++ b/react/ImageSlider.tsx
@@ -37,6 +37,8 @@ function ImageSlider(props: ImageSliderProps) {
   const { isMobile } = useDevice()
   const intl = useIntl()
 
+  console.log('use preload')
+
   return (
     <SliderLayout {...sliderLayoutConfig} totalItems={images.length}>
       {images.map(
@@ -62,6 +64,7 @@ function ImageSlider(props: ImageSliderProps) {
               link={imageLink}
               maxHeight={height}
               width="100%"
+              preload={idx === 0}
               {...otherProps}
             />
           )

--- a/react/ImageSlider.tsx
+++ b/react/ImageSlider.tsx
@@ -11,6 +11,7 @@ export interface ImageSliderProps {
   images: ImagesSchema
   height: number
   sliderLayoutConfig: SliderConfig
+  preload?: boolean
 }
 
 function getImageUrl(isMobile: boolean, image: string, mobileImage: string) {
@@ -32,6 +33,7 @@ function ImageSlider(props: ImageSliderProps) {
       showPaginationDots: 'always',
       usePagination: true,
     },
+    preload,
   } = props
 
   const { isMobile } = useDevice()
@@ -62,7 +64,7 @@ function ImageSlider(props: ImageSliderProps) {
               link={imageLink}
               maxHeight={height}
               width="100%"
-              preload={idx === 0}
+              preload={preload && idx === 0}
               {...otherProps}
             />
           )

--- a/react/ImageSlider.tsx
+++ b/react/ImageSlider.tsx
@@ -37,8 +37,6 @@ function ImageSlider(props: ImageSliderProps) {
   const { isMobile } = useDevice()
   const intl = useIntl()
 
-  console.log('use preload')
-
   return (
     <SliderLayout {...sliderLayoutConfig} totalItems={images.length}>
       {images.map(

--- a/react/modules/imageAsList.tsx
+++ b/react/modules/imageAsList.tsx
@@ -6,7 +6,8 @@ import type { ImagesSchema } from '../ImageTypes'
 export const getImagesAsJSXList = (
   images: ImagesSchema,
   isMobile: boolean,
-  height: string | number
+  height: string | number,
+  preload?: boolean
 ) => {
   return images.map(
     (
@@ -27,6 +28,7 @@ export const getImagesAsJSXList = (
         maxHeight={height}
         width={width}
         experimentalPreventLayoutShift={experimentalPreventLayoutShift}
+        preload={preload}
         {...props}
       />
     )

--- a/react/modules/imageAsList.tsx
+++ b/react/modules/imageAsList.tsx
@@ -28,7 +28,7 @@ export const getImagesAsJSXList = (
         maxHeight={height}
         width={width}
         experimentalPreventLayoutShift={experimentalPreventLayoutShift}
-        preload={preload}
+        preload={preload && idx === 0}
         {...props}
       />
     )


### PR DESCRIPTION
#### What problem is this solving?

Allows preloading the first of the image-list images, via an attribute that automatically inserts the preload tag on the head, done by render-runtime

#### How to test it?

Go to https://storetheme.vtex.com/?workspace=lbebberpreload1&v=00001

Open the source code and search for `as="image"`

You should find the following string 

`<link data-react-helmet="true" rel="preload" as="image" href="https://storecomponents.vtexassets.com/assets/vtex.file-manager-graphql/images/bd025904-c013-472a-99fc-dc26ccc7238c___f9dfe8885768021f405cc624eb6c20cd.jpg" crossOrigin="anonymous"/>`

The same will not happen on https://storetheme.vtex.com

#### Screenshots or example usage:

<!--- Add some images or gifs to showcase changes in behaviour or layout. Example: before and after images -->

#### Describe alternatives you've considered, if any.

<!--- Optional -->

#### Related to / Depends on

<!--- Optional -->

#### How does this PR make you feel? [:link:](http://giphy.com/)

<!-- Go to http://giphy.com/ and pick a gif that represents how this PR makes you feel -->

![](put .gif link here - can be found under "advanced" on giphy)
