### PR TITLE
Prevent trigger promoView event when isDuplicated

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -6,6 +6,11 @@ The format is based on [Keep a Changelog](http://keepachangelog.com/en/1.0.0/)
 and this project adheres to [Semantic Versioning](http://semver.org/spec/v2.0.0.html).
 
 ## [Unreleased]
+### Fixed
+- `Image`: Prevent trigger promoView event when `__isDuplicated` is enabled.
+
+### Added
+- `Image`:  `__isDuplicated` prop to handle when an image is duplicated inside the slider-layout.
 
 ## [0.12.1] - 2021-09-06
 ### Fixed

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,7 +7,7 @@ and this project adheres to [Semantic Versioning](http://semver.org/spec/v2.0.0.
 
 ## [Unreleased]
 ### Fixed
-- `Image`: Prevent trigger promoView event when `__isDuplicated` is enabled.
+- `Image`: Prevent to trigger promoView event when `__isDuplicated` is enabled.
 
 ### Added
 - `Image`:  `__isDuplicated` prop to handle when an image is duplicated inside the slider-layout.

--- a/react/Image.tsx
+++ b/react/Image.tsx
@@ -22,6 +22,7 @@ export interface ImageProps
   experimentalPreventLayoutShift?: boolean
   classes?: CssHandlesTypes.CustomClasses<typeof CSS_HANDLES>
   preload?: boolean
+  __isDuplicated?: boolean
 }
 
 const useImageLoad = (
@@ -82,6 +83,9 @@ function Image(props: ImageProps) {
     promotionPosition,
     classes,
     preload,
+    // Do not use this property
+    // eslint-disable-next-line
+    __isDuplicated,
   } = props
 
   const imageRef = useRef<HTMLImageElement | null>(null)
@@ -119,9 +123,11 @@ function Image(props: ImageProps) {
       style={imageDimensions}
       ref={imageRef}
       className={handles.imageElement}
-      {...(preload ? {
-        'data-vtex-preload': 'true'
-      } : {})}
+      {...(preload
+        ? {
+            'data-vtex-preload': 'true',
+          }
+        : {})}
     />
   )
 
@@ -165,7 +171,7 @@ function Image(props: ImageProps) {
   useOnView({
     ref: imageRef,
     onView: () => {
-      if (analyticsProperties === 'none') return
+      if (analyticsProperties === 'none' || __isDuplicated) return
 
       push({
         event: 'promoView',

--- a/react/Image.tsx
+++ b/react/Image.tsx
@@ -23,8 +23,8 @@ export interface ImageProps
   classes?: CssHandlesTypes.CustomClasses<typeof CSS_HANDLES>
   preload?: boolean
   /**
-   * Warning: This property is for internal usage, please avoid use it.
-   * This property is used when the Image is children of SliderTrack component and prevents to trigger the promoView event twice for cloned images.
+   * Warning: This property is for internal usage, please avoid using it.
+   * This property is used when the Image is children of the SliderTrack component and it prevents triggering the promoView event twice for cloned images.
    * https://github.com/vtex-apps/slider-layout/blob/master/react/components/SliderTrack.tsx
    */
   __isDuplicated?: boolean

--- a/react/Image.tsx
+++ b/react/Image.tsx
@@ -22,6 +22,11 @@ export interface ImageProps
   experimentalPreventLayoutShift?: boolean
   classes?: CssHandlesTypes.CustomClasses<typeof CSS_HANDLES>
   preload?: boolean
+  /**
+   * Warning: This property is for internal usage, please avoid use it.
+   * This property is used when the Image is children of SliderTrack component and prevents to trigger the promoView event twice for cloned images.
+   * https://github.com/vtex-apps/slider-layout/blob/master/react/components/SliderTrack.tsx
+   */
   __isDuplicated?: boolean
 }
 
@@ -83,7 +88,6 @@ function Image(props: ImageProps) {
     promotionPosition,
     classes,
     preload,
-    // Do not use this property
     // eslint-disable-next-line
     __isDuplicated,
   } = props


### PR DESCRIPTION
#### What problem is this solving?
When an Image is inside the slider-layout, some of them are duplicated, due to this, a `promoView` is triggered twice.
To fix it, when __isDisabled is true the Image component doesn't trigger the `promoView` event.

#### How to test it?
1. Go to the [Workspace](https://brasileiro--storecomponents.myvtex.com/)
2. Click on the carousel arrows until you get the first image again
3. Check if the promoView event is not triggered twice for the first image.

#### Screenshots or example usage:

#### Describe alternatives you've considered, if any.

Make the slider-layout pass `analyticsProperties: none` when a child is duplicated.

#### Related to / Depends on
https://github.com/vtex-apps/slider-layout/pull/73/

#### How does this PR make you feel? [:link:](http://giphy.com/)
![](https://media.giphy.com/media/lKXEBR8m1jWso/giphy.gif?cid=ecf05e47yt3doxoyv5juvpupha4y9fmpmjc3f5waunpmcawy&rid=giphy.gif&ct=g)
