### PR TITLE
add phone image prop

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -6,6 +6,8 @@ The format is based on [Keep a Changelog](http://keepachangelog.com/en/1.0.0/)
 and this project adheres to [Semantic Versioning](http://semver.org/spec/v2.0.0.html).
 
 ## [Unreleased]
+### Add
+- phone image
 
 ## [0.14.1] - 2021-10-01
 ### Fixed

--- a/messages/bg-BG.json
+++ b/messages/bg-BG.json
@@ -9,6 +9,7 @@
   "admin/editor.image-list.images.title": "Изображения",
   "admin/editor.image-list.images.image.title": "Изображение",
   "admin/editor.image-list.images.mobileImage.title": "Изображение за мобилно устройство",
+  "admin/editor.image-list.images.phoneImage.title": "изображение на мобилен телефон",
   "admin/editor.image-list.images.description.title": "Алтернативен текст за изображение",
   "admin/editor.image-list.images.title.title": "Заглавие на изображение",
   "admin/editor.image-list.images.link.url.title": "URL адрес с линк за изображението",

--- a/messages/bg-BG.json
+++ b/messages/bg-BG.json
@@ -9,7 +9,7 @@
   "admin/editor.image-list.images.title": "Изображения",
   "admin/editor.image-list.images.image.title": "Изображение",
   "admin/editor.image-list.images.mobileImage.title": "Изображение за мобилно устройство",
-  "admin/editor.image-list.images.phoneImage.title": "изображение на мобилен телефон",
+  "admin/editor.image-list.images.phoneImage.title": "Изображение за телефон",
   "admin/editor.image-list.images.description.title": "Алтернативен текст за изображение",
   "admin/editor.image-list.images.title.title": "Заглавие на изображение",
   "admin/editor.image-list.images.link.url.title": "URL адрес с линк за изображението",

--- a/messages/context.json
+++ b/messages/context.json
@@ -9,6 +9,7 @@
   "admin/editor.image-list.images.title": "Images",
   "admin/editor.image-list.images.image.title": "Image",
   "admin/editor.image-list.images.mobileImage.title": "Image for mobile",
+  "admin/editor.image-list.images.phoneImage.title": "Image for phone",
   "admin/editor.image-list.images.description.title": "Image alt text",
   "admin/editor.image-list.images.title.title": "Image title",
   "admin/editor.image-list.images.link.url.title": "Image link URL",

--- a/messages/en.json
+++ b/messages/en.json
@@ -9,6 +9,7 @@
   "admin/editor.image-list.images.title": "Images",
   "admin/editor.image-list.images.image.title": "Image",
   "admin/editor.image-list.images.mobileImage.title": "Image for mobile",
+  "admin/editor.image-list.images.phoneImage.title": "Image for phone",
   "admin/editor.image-list.images.description.title": "Image alt text",
   "admin/editor.image-list.images.title.title": "Image title",
   "admin/editor.image-list.images.link.url.title": "Image link URL",

--- a/messages/es.json
+++ b/messages/es.json
@@ -9,6 +9,7 @@
   "admin/editor.image-list.images.title": "Imágenes",
   "admin/editor.image-list.images.image.title": "Imagen",
   "admin/editor.image-list.images.mobileImage.title": "Imagen para móvil",
+  "admin/editor.image-list.images.phoneImage.title": "Imagen para celular",
   "admin/editor.image-list.images.description.title": "Texto alternativo de la imagen",
   "admin/editor.image-list.images.title.title": "Título de la imagen",
   "admin/editor.image-list.images.link.url.title": "URL del enlace de la imagen",

--- a/messages/fr-FR.json
+++ b/messages/fr-FR.json
@@ -9,6 +9,7 @@
   "admin/editor.image-list.images.title": "Images",
   "admin/editor.image-list.images.image.title": "Photo",
   "admin/editor.image-list.images.mobileImage.title": "Image pour mobile",
+  "admin/editor.image-list.images.phoneImage.title": "Image pour téléphone portable",
   "admin/editor.image-list.images.description.title": "Texte de remplacement de l’image",
   "admin/editor.image-list.images.title.title": "Titre de l’mage",
   "admin/editor.image-list.images.link.url.title": "URL du lien de l’image",

--- a/messages/it-IT.json
+++ b/messages/it-IT.json
@@ -9,6 +9,7 @@
   "admin/editor.image-list.images.title": "Immagini",
   "admin/editor.image-list.images.image.title": "Immagine",
   "admin/editor.image-list.images.mobileImage.title": "Immagine per dispositivi mobili",
+  "admin/editor.image-list.images.phoneImage.title": "Immagine per telefonino",
   "admin/editor.image-list.images.description.title": "Descrizione alternativa dell'immagine",
   "admin/editor.image-list.images.title.title": "Titolo dell'immagine",
   "admin/editor.image-list.images.link.url.title": "URL del link dell'immagine",

--- a/messages/it-IT.json
+++ b/messages/it-IT.json
@@ -9,7 +9,7 @@
   "admin/editor.image-list.images.title": "Immagini",
   "admin/editor.image-list.images.image.title": "Immagine",
   "admin/editor.image-list.images.mobileImage.title": "Immagine per dispositivi mobili",
-  "admin/editor.image-list.images.phoneImage.title": "Immagine per telefonino",
+  "admin/editor.image-list.images.phoneImage.title": "Immagine per cellulari",
   "admin/editor.image-list.images.description.title": "Descrizione alternativa dell'immagine",
   "admin/editor.image-list.images.title.title": "Titolo dell'immagine",
   "admin/editor.image-list.images.link.url.title": "URL del link dell'immagine",

--- a/messages/ja-JP.json
+++ b/messages/ja-JP.json
@@ -9,6 +9,7 @@
   "admin/editor.image-list.images.title": "画像",
   "admin/editor.image-list.images.image.title": "画像",
   "admin/editor.image-list.images.mobileImage.title": "モバイル用画像",
+  "admin/editor.image-list.images.phoneImage.title": "携帯電話用画像",
   "admin/editor.image-list.images.description.title": "画像代替テキスト",
   "admin/editor.image-list.images.title.title": "画像のタイトル",
   "admin/editor.image-list.images.link.url.title": "画像リンク URL",

--- a/messages/ja-JP.json
+++ b/messages/ja-JP.json
@@ -9,7 +9,7 @@
   "admin/editor.image-list.images.title": "画像",
   "admin/editor.image-list.images.image.title": "画像",
   "admin/editor.image-list.images.mobileImage.title": "モバイル用画像",
-  "admin/editor.image-list.images.phoneImage.title": "携帯電話用画像",
+  "admin/editor.image-list.images.phoneImage.title": "電話用画像",
   "admin/editor.image-list.images.description.title": "画像代替テキスト",
   "admin/editor.image-list.images.title.title": "画像のタイトル",
   "admin/editor.image-list.images.link.url.title": "画像リンク URL",

--- a/messages/ko-KR.json
+++ b/messages/ko-KR.json
@@ -9,7 +9,7 @@
   "admin/editor.image-list.images.title": "이미지",
   "admin/editor.image-list.images.image.title": "이미지",
   "admin/editor.image-list.images.mobileImage.title": "모바일용 이미지",
-  "admin/editor.image-list.images.phoneImage.title": "휴대폰용 이미지",
+  "admin/editor.image-list.images.phoneImage.title": "휴대폰의 이미지",
   "admin/editor.image-list.images.description.title": "이미지 alt 텍스트",
   "admin/editor.image-list.images.title.title": "이미지 제목",
   "admin/editor.image-list.images.link.url.title": "이미지 링크 URL",

--- a/messages/ko-KR.json
+++ b/messages/ko-KR.json
@@ -9,6 +9,7 @@
   "admin/editor.image-list.images.title": "이미지",
   "admin/editor.image-list.images.image.title": "이미지",
   "admin/editor.image-list.images.mobileImage.title": "모바일용 이미지",
+  "admin/editor.image-list.images.phoneImage.title": "휴대폰용 이미지",
   "admin/editor.image-list.images.description.title": "이미지 alt 텍스트",
   "admin/editor.image-list.images.title.title": "이미지 제목",
   "admin/editor.image-list.images.link.url.title": "이미지 링크 URL",

--- a/messages/nl-NL.json
+++ b/messages/nl-NL.json
@@ -9,6 +9,7 @@
   "admin/editor.image-list.images.title": "Afbeeldingen",
   "admin/editor.image-list.images.image.title": "Afbeelding",
   "admin/editor.image-list.images.mobileImage.title": "Afbeelding voor mobiel",
+  "admin/editor.image-list.images.phoneImage.title": "Afbeelding voor mobiel telefoon",
   "admin/editor.image-list.images.description.title": "Afbeelding alt-tekst",
   "admin/editor.image-list.images.title.title": "Titel van de afbeelding",
   "admin/editor.image-list.images.link.url.title": "URL van afbeeldingslink",

--- a/messages/pt.json
+++ b/messages/pt.json
@@ -9,6 +9,7 @@
   "admin/editor.image-list.images.title": "Imagens",
   "admin/editor.image-list.images.image.title": "Imagem",
   "admin/editor.image-list.images.mobileImage.title": "Imagem para mobile",
+  "admin/editor.image-list.images.phoneImage.title": "Imagem para celular",
   "admin/editor.image-list.images.description.title": "Descrição alternativa para a imagem",
   "admin/editor.image-list.images.title.title": "Título da imagem",
   "admin/editor.image-list.images.link.url.title": "URL do link da imagem",

--- a/messages/ro-RO.json
+++ b/messages/ro-RO.json
@@ -9,6 +9,7 @@
   "admin/editor.image-list.images.title": "Imagini",
   "admin/editor.image-list.images.image.title": "Imagine",
   "admin/editor.image-list.images.mobileImage.title": "Imagini pentru mobil",
+  "admin/editor.image-list.images.phoneImage.title": "Imagini pentru telefon mobil",
   "admin/editor.image-list.images.description.title": "Text imagine alternativă",
   "admin/editor.image-list.images.title.title": "Titlu imagine",
   "admin/editor.image-list.images.link.url.title": "URL link imagine",

--- a/messages/ro-RO.json
+++ b/messages/ro-RO.json
@@ -9,7 +9,7 @@
   "admin/editor.image-list.images.title": "Imagini",
   "admin/editor.image-list.images.image.title": "Imagine",
   "admin/editor.image-list.images.mobileImage.title": "Imagini pentru mobil",
-  "admin/editor.image-list.images.phoneImage.title": "Imagini pentru telefon mobil",
+  "admin/editor.image-list.images.phoneImage.title": "Imagine pentru telefon mobil",
   "admin/editor.image-list.images.description.title": "Text imagine alternativă",
   "admin/editor.image-list.images.title.title": "Titlu imagine",
   "admin/editor.image-list.images.link.url.title": "URL link imagine",

--- a/react/ImageList.tsx
+++ b/react/ImageList.tsx
@@ -8,7 +8,7 @@ import { getImagesAsJSXList } from './modules/imageAsList'
 import type { ImagesSchema } from './ImageTypes'
 
 export interface ImageListProps {
-  images: ImagesSchema 
+  images: ImagesSchema
   height?: number
   preload?: boolean
 }

--- a/react/ImageList.tsx
+++ b/react/ImageList.tsx
@@ -8,7 +8,7 @@ import { getImagesAsJSXList } from './modules/imageAsList'
 import type { ImagesSchema } from './ImageTypes'
 
 export interface ImageListProps {
-  images: ImagesSchema
+  images: ImagesSchema 
   height?: number
   preload?: boolean
 }
@@ -20,9 +20,9 @@ function ImageList({
   preload,
 }: PropsWithChildren<ImageListProps>) {
   const list = useListContext()?.list ?? []
-  const { isMobile } = useDevice()
+  const { device } = useDevice()
 
-  const imageListContent = getImagesAsJSXList(images, isMobile, height, preload)
+  const imageListContent = getImagesAsJSXList(images, device, height, preload)
   const newListContextValue = list.concat(imageListContent)
 
   return (

--- a/react/ImageListWithoutContext.tsx
+++ b/react/ImageListWithoutContext.tsx
@@ -7,9 +7,9 @@ import type { ImageListProps } from './ImageList'
 
 const ImageListWithoutContext = (props: ImageListProps) => {
   const { images, height = 420 } = props
-  const { isMobile } = useDevice()
+  const { device } = useDevice()
 
-  const imageListContent = getImagesAsJSXList(images, isMobile, height)
+  const imageListContent = getImagesAsJSXList(images, device, height)
 
   return <React.Fragment>{imageListContent}</React.Fragment>
 }

--- a/react/ImageTypes.ts
+++ b/react/ImageTypes.ts
@@ -17,8 +17,8 @@ export interface ImageSchema {
 
 export type ImagesSchema = Array<{
   image: string
-  mobileImage: string,
-  phoneImage: string,
+  mobileImage: string
+  phoneImage: string
   link?: Link
   title?: string
   description: string

--- a/react/ImageTypes.ts
+++ b/react/ImageTypes.ts
@@ -17,7 +17,8 @@ export interface ImageSchema {
 
 export type ImagesSchema = Array<{
   image: string
-  mobileImage: string
+  mobileImage: string,
+  phoneImage: string,
   link?: Link
   title?: string
   description: string

--- a/react/modules/imageAsList.tsx
+++ b/react/modules/imageAsList.tsx
@@ -9,14 +9,19 @@ interface ResponsiveImageParams {
   mobileImage: string
   phoneImage: string
 }
-const getResponsiveImage = ({ device, image, mobileImage, phoneImage }: ResponsiveImageParams) => {
-  let currentImage = image;
+const getResponsiveImage = ({
+  device,
+  image,
+  mobileImage,
+  phoneImage,
+}: ResponsiveImageParams) => {
+  let currentImage = image
 
-  if( device == 'tablet' && mobileImage) currentImage = mobileImage;
-  if(device == 'phone' && phoneImage) currentImage = phoneImage;
-  else if (device == 'phone' && mobileImage) currentImage = mobileImage;
-  
-  return currentImage;
+  if (device === 'tablet' && mobileImage) currentImage = mobileImage
+  if (device === 'phone' && phoneImage) currentImage = phoneImage
+  else if (device === 'phone' && mobileImage) currentImage = mobileImage
+
+  return currentImage
 }
 
 export const getImagesAsJSXList = (
@@ -38,20 +43,25 @@ export const getImagesAsJSXList = (
       },
       idx
     ) => {
-      
-      const currentImage = getResponsiveImage(device, image, mobileImage,phoneImage)
-      
+      const currentImage = getResponsiveImage(
+        device,
+        image,
+        mobileImage,
+        phoneImage
+      )
+
       return (
-      <Image
-        key={idx}
-        src={currentImage}
-        alt={description}
-        maxHeight={height}
-        width={width}
-        experimentalPreventLayoutShift={experimentalPreventLayoutShift}
-        preload={preload && idx === 0}
-        {...props}
-      />)
+        <Image
+          key={idx}
+          src={currentImage}
+          alt={description}
+          maxHeight={height}
+          width={width}
+          experimentalPreventLayoutShift={experimentalPreventLayoutShift}
+          preload={preload && idx === 0}
+          {...props}
+        />
+      )
     }
   )
 }

--- a/react/modules/imageAsList.tsx
+++ b/react/modules/imageAsList.tsx
@@ -43,12 +43,12 @@ export const getImagesAsJSXList = (
       },
       idx
     ) => {
-      const currentImage = getResponsiveImage(
+      const currentImage = getResponsiveImage({
         device,
         image,
         mobileImage,
-        phoneImage
-      )
+        phoneImage,
+      })
 
       return (
         <Image

--- a/react/modules/imageAsList.tsx
+++ b/react/modules/imageAsList.tsx
@@ -3,7 +3,13 @@ import React from 'react'
 import Image from '../Image'
 import type { ImagesSchema } from '../ImageTypes'
 
-const getResponsiveImage = (device: string, image: string, mobileImage: string,phoneImage: string) => {
+interface ResponsiveImageParams {
+  device: string
+  image: string
+  mobileImage: string
+  phoneImage: string
+}
+const getResponsiveImage = ({ device, image, mobileImage, phoneImage }: ResponsiveImageParams) => {
   let currentImage = image;
 
   if( device == 'tablet' && mobileImage) currentImage = mobileImage;

--- a/react/modules/imageAsList.tsx
+++ b/react/modules/imageAsList.tsx
@@ -3,9 +3,19 @@ import React from 'react'
 import Image from '../Image'
 import type { ImagesSchema } from '../ImageTypes'
 
+const getResponsiveImage = (device: string, image: string, mobileImage: string,phoneImage: string) => {
+  let currentImage = image;
+
+  if( device == 'tablet' && mobileImage) currentImage = mobileImage;
+  if(device == 'phone' && phoneImage) currentImage = phoneImage;
+  else if (device == 'phone' && mobileImage) currentImage = mobileImage;
+  
+  return currentImage;
+}
+
 export const getImagesAsJSXList = (
   images: ImagesSchema,
-  isMobile: boolean,
+  device: string,
   height: string | number,
   preload?: boolean
 ) => {
@@ -14,23 +24,28 @@ export const getImagesAsJSXList = (
       {
         image,
         mobileImage,
+        phoneImage,
         description,
         experimentalPreventLayoutShift,
         width = '100%',
         ...props
       },
       idx
-    ) => (
+    ) => {
+      
+      const currentImage = getResponsiveImage(device, image, mobileImage,phoneImage)
+      
+      return (
       <Image
         key={idx}
-        src={isMobile && mobileImage ? mobileImage : image}
+        src={currentImage}
         alt={description}
         maxHeight={height}
         width={width}
         experimentalPreventLayoutShift={experimentalPreventLayoutShift}
         preload={preload && idx === 0}
         {...props}
-      />
-    )
+      />)
+    }
   )
 }

--- a/store/contentSchemas.json
+++ b/store/contentSchemas.json
@@ -100,7 +100,7 @@
           "phoneImage": {
             "$ref": "app:vtex.native-types#/definitions/url",
             "default": "",
-            "title": "admin/editor.image-list.images.mobileImage.title",
+            "title": "admin/editor.image-list.images.phoneImage.title",
             "widget": {
               "ui:widget": "image-uploader"
             }

--- a/store/contentSchemas.json
+++ b/store/contentSchemas.json
@@ -97,6 +97,14 @@
               "ui:widget": "image-uploader"
             }
           },
+          "phoneImage": {
+            "$ref": "app:vtex.native-types#/definitions/url",
+            "default": "",
+            "title": "admin/editor.image-list.images.mobileImage.title",
+            "widget": {
+              "ui:widget": "image-uploader"
+            }
+          },
           "description": {
             "$ref": "app:vtex.native-types#/definitions/text",
             "default": "",

--- a/store/interfaces.json
+++ b/store/interfaces.json
@@ -2,7 +2,7 @@
   "image-new": {
     "component": "Image",
     "content": {
-      "$ref": "app:sudambeef.store-image#/definitions/Image"
+      "$ref": "app:vtex.store-image#/definitions/Image"
     }
   },
   "image-slider": {
@@ -10,7 +10,7 @@
     "content": {
       "properties": {
         "images": {
-          "$ref": "app:sudambeef.store-image#/definitions/Images"
+          "$ref": "app:vtex.store-image#/definitions/Images"
         }
       }
     }
@@ -20,7 +20,7 @@
     "content": {
       "properties": {
         "images": {
-          "$ref": "app:sudambeef.store-image#/definitions/Images"
+          "$ref": "app:vtex.store-image#/definitions/Images"
         }
       }
     }
@@ -32,7 +32,7 @@
     "content": {
       "properties": {
         "images": {
-          "$ref": "app:sudambeef.store-image#/definitions/Images"
+          "$ref": "app:vtex.store-image#/definitions/Images"
         }
       }
     }

--- a/store/interfaces.json
+++ b/store/interfaces.json
@@ -2,7 +2,7 @@
   "image-new": {
     "component": "Image",
     "content": {
-      "$ref": "app:vtex.store-image#/definitions/Image"
+      "$ref": "app:sudambeef.store-image#/definitions/Image"
     }
   },
   "image-slider": {
@@ -10,7 +10,7 @@
     "content": {
       "properties": {
         "images": {
-          "$ref": "app:vtex.store-image#/definitions/Images"
+          "$ref": "app:sudambeef.store-image#/definitions/Images"
         }
       }
     }
@@ -20,7 +20,7 @@
     "content": {
       "properties": {
         "images": {
-          "$ref": "app:vtex.store-image#/definitions/Images"
+          "$ref": "app:sudambeef.store-image#/definitions/Images"
         }
       }
     }
@@ -32,7 +32,7 @@
     "content": {
       "properties": {
         "images": {
-          "$ref": "app:vtex.store-image#/definitions/Images"
+          "$ref": "app:sudambeef.store-image#/definitions/Images"
         }
       }
     }


### PR DESCRIPTION
#### What problem is this solving?

This prop alows to use other image for phone size.  

#### How to test it?

just add the block in your theme and pass phoneImage prop

[Workspace](https://sudambeef--agenciaeplus.myvtex.com/)

#### Screenshots or example usage:

<!--- Add some images or gifs to showcase changes in behaviour or layout. Example: before and after images -->
desktop
![image](https://user-images.githubusercontent.com/48053804/136847573-0e8f0674-ffb7-4298-8f8f-e771b973ddf5.png)

mobile / tablet
![image](https://user-images.githubusercontent.com/48053804/136847627-3d69cb1b-1c2d-4c6c-b53c-894e0727b911.png)

phone
![image](https://user-images.githubusercontent.com/48053804/136847662-c3062afe-7669-4a1c-86c7-6a3cdc11d273.png)

obs: is just test images.

#### Describe alternatives you've considered, if any.

use Responsive layout can be usefull but this is more work to the client.
