### PR TITLE
Feat/inline tag attributes

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -6,7 +6,8 @@ The format is based on [Keep a Changelog](http://keepachangelog.com/en/1.0.0/)
 and this project adheres to [Semantic Versioning](http://semver.org/spec/v2.0.0.html).
 
 ## [Unreleased]
-
+### Added 
+- `tagWidth` and `tagHeight` props to `Image` component.
 ## [0.14.2] - 2021-10-13
 ### Fixed
 - Add Image title removed.

--- a/docs/README.md
+++ b/docs/README.md
@@ -61,28 +61,30 @@ Note that the `slider-layout` block, exported from the Slider Layout app, is giv
 
 ### `list-context.image-list` props
 
-| Prop name | Type     | Description                                                   | Default value |
-| --------- | -------- | ------------------------------------------------------------- | ------------- |
-| `images`  | `array`  | Array of objects declaring all desired images to be rendered. | `undefined`   |
-| `height`  | `number` | Image height for all images declared in the `image` object (in `px`).   | `undefined`   |
-| `preload`  | `boolean` | Preloads the first image in a list, which helps prioritizing the display of images over other assets | `false`   |
+| Prop name | Type      | Description                                                                                          | Default value |
+| --------- | --------- | ---------------------------------------------------------------------------------------------------- | ------------- |
+| `images`  | `array`   | Array of objects declaring all desired images to be rendered.                                        | `undefined`   |
+| `height`  | `number`  | Image height for all images declared in the `image` object (in `px`).                                | `undefined`   |
+| `preload` | `boolean` | Preloads the first image in a list, which helps prioritizing the display of images over other assets | `false`       |
 
 ### `image-list` props
 
-| Prop name | Type     | Description                                                   | Default value |
-| --------- | -------- | ------------------------------------------------------------- | ------------- |
-| `images`  | `array`  | Array of objects declaring all desired images to be rendered. | `undefined`   |
-| `height`  | `number` | Image height for all images declared in the `image` object (in `px`).   | `undefined`   |
+| Prop name | Type     | Description                                                           | Default value |
+| --------- | -------- | --------------------------------------------------------------------- | ------------- |
+| `images`  | `array`  | Array of objects declaring all desired images to be rendered.         | `undefined`   |
+| `height`  | `number` | Image height for all images declared in the `image` object (in `px`). | `undefined`   |
 
 - **`images` array:**
 
-| Prop name     | Type     | Description                               | Default value |
-| ------------- | -------- | ----------------------------------------- | ------------- |
-| `image`       | `string` | Image URL.                                | `undefined`   |
-| `mobileImage` | `string` | Mobile image URL.                         | `undefined`   |
-| `description` | `string` | Image description.                        | `undefined`   |
-| `link`        | `object` | Links an URL to the image being rendered. | `undefined`   |
-| `width` | `string` / `number` | Image width (in `%` or `px`). | `100%` |
+| Prop name     | Type                | Description                               | Default value |
+| ------------- | ------------------- | ----------------------------------------- | ------------- |
+| `image`       | `string`            | Image URL.                                | `undefined`   |
+| `mobileImage` | `string`            | Mobile image URL.                         | `undefined`   |
+| `description` | `string`            | Image description.                        | `undefined`   |
+| `link`        | `object`            | Links an URL to the image being rendered. | `undefined`   |
+| `width`       | `string` / `number` | Image width (in `%` or `px`).             | `100%`        |
+| `tagWidth`    | `string` / `number` | Image width (in `%` or `px`).             | `undefined`   |
+| `tagHeight`   | `string` / `number` | Image width (in `%` or `px`).             | `undefined`   |
 
 - **`link` object:**
 

--- a/react/Image.tsx
+++ b/react/Image.tsx
@@ -23,6 +23,8 @@ export interface ImageProps
   experimentalPreventLayoutShift?: boolean
   classes?: CssHandlesTypes.CustomClasses<typeof CSS_HANDLES>
   preload?: boolean
+  tagWidth?: string | number
+  tagHeight?: string | number
   /**
    * Warning: This property is for internal usage, please avoid using it.
    * This property is used when the Image is children of the SliderTrack component and it prevents triggering the promoView event twice for cloned images.
@@ -89,6 +91,8 @@ function Image(props: ImageProps) {
     promotionPosition,
     classes,
     preload,
+    tagWidth,
+    tagHeight,
     // eslint-disable-next-line
     __isDuplicated,
   } = props
@@ -133,6 +137,8 @@ function Image(props: ImageProps) {
             'data-vtex-preload': 'true',
           }
         : {})}
+      width={tagWidth}
+      height={tagHeight}
     />
   )
 


### PR DESCRIPTION
#### What problem is this solving?

- Set an explicit width and height on image elements to reduce layout shifts and improve CLS

#### How to test it?

- Log into the workspace, go to a product page and make a lighthouse test

[Workspace](https://testwidth--rihappynovo.myvtex.com/lego-city---fire-helicopter---60318/p)

#### Screenshots or example usage:

Before:

![image](https://user-images.githubusercontent.com/53482121/155603901-90f29aee-398e-4218-9beb-a11554811d79.png)


After:

![image](https://user-images.githubusercontent.com/53482121/155603694-7c1b97ae-28d6-44ca-ac62-d3abe4f67ef3.png)



#### Describe alternatives you've considered, if any.

N/A

#### Related to / Depends on

N/A

#### How does this PR make you feel? [:link:](http://giphy.com/)

<!-- Go to http://giphy.com/ and pick a gif that represents how this PR makes you feel -->

![](https://media.giphy.com/media/pFuQkU1HWZ4khyVYFt/giphy.gif)
