### PR TITLE
Add experimentalPreventLayoutShift prop to ImageList

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,6 +7,9 @@ and this project adheres to [Semantic Versioning](http://semver.org/spec/v2.0.0.
 
 ## [Unreleased]
 
+### Added
+- Support for `experimentalPreventLayoutShift` prop in `ImageList` which will apply the setting to all child images
+
 ## [0.14.2] - 2021-10-13
 ### Fixed
 - Add Image title removed.

--- a/react/ImageList.tsx
+++ b/react/ImageList.tsx
@@ -11,6 +11,7 @@ export interface ImageListProps {
   images: ImagesSchema
   height?: number
   preload?: boolean
+  experimentalPreventLayoutShift?: boolean
 }
 
 function ImageList({
@@ -18,11 +19,19 @@ function ImageList({
   height = 420,
   children,
   preload,
+  experimentalPreventLayoutShift,
 }: PropsWithChildren<ImageListProps>) {
   const list = useListContext()?.list ?? []
   const { isMobile } = useDevice()
 
-  const imageListContent = getImagesAsJSXList(images, isMobile, height, preload)
+  const imageListContent = getImagesAsJSXList(
+    images,
+    isMobile,
+    height,
+    preload,
+    experimentalPreventLayoutShift
+  )
+
   const newListContextValue = list.concat(imageListContent)
 
   return (

--- a/react/modules/imageAsList.tsx
+++ b/react/modules/imageAsList.tsx
@@ -7,7 +7,8 @@ export const getImagesAsJSXList = (
   images: ImagesSchema,
   isMobile: boolean,
   height: string | number,
-  preload?: boolean
+  preload?: boolean,
+  experimentalPreventLayoutShift?: boolean
 ) => {
   return images.map(
     (
@@ -15,7 +16,7 @@ export const getImagesAsJSXList = (
         image,
         mobileImage,
         description,
-        experimentalPreventLayoutShift,
+        experimentalPreventLayoutShift: experimentalPreventLayoutShiftChild,
         width = '100%',
         ...props
       },
@@ -27,7 +28,9 @@ export const getImagesAsJSXList = (
         alt={description}
         maxHeight={height}
         width={width}
-        experimentalPreventLayoutShift={experimentalPreventLayoutShift}
+        experimentalPreventLayoutShift={
+          experimentalPreventLayoutShift ?? experimentalPreventLayoutShiftChild
+        }
         preload={preload && idx === 0}
         {...props}
       />


### PR DESCRIPTION
#### What problem is this solving?

If a user wanted to use the `experimentalPreventLayoutShift` prop for every image in an `ImageList`, previously they would have to set the prop individually on every image in the list. 

This PR allows the prop to be set on the list itself, which if set to `true` will have the effect of setting the prop to `true` for all of its child images.

#### How to test it?

Linked here along with a theme that applies the new prop to the main image slider on the homepage: https://arthur--sandboxusdev.myvtex.com/