### PR TITLE
Add new experimentalSetExplicitDimensions prop

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -9,7 +9,7 @@ and this project adheres to [Semantic Versioning](http://semver.org/spec/v2.0.0.
 
 ### Added
 
-- `experimentalSetExplicitDimensions` prop for `Image`
+- `experimentalSetExplicitDimensions` prop for `Image` and `ImageList`
 
 ## [0.15.0] - 2022-09-08
 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,6 +7,10 @@ and this project adheres to [Semantic Versioning](http://semver.org/spec/v2.0.0.
 
 ## [Unreleased]
 
+### Added
+
+- `experimentalSetExplicitDimensions` prop for `Image`
+
 ## [0.15.0] - 2022-09-08
 
 ### Added

--- a/docs/README.md
+++ b/docs/README.md
@@ -61,28 +61,29 @@ Note that the `slider-layout` block, exported from the Slider Layout app, is giv
 
 ### `list-context.image-list` props
 
-| Prop name | Type     | Description                                                   | Default value |
-| --------- | -------- | ------------------------------------------------------------- | ------------- |
-| `images`  | `array`  | Array of objects declaring all desired images to be rendered. | `undefined`   |
-| `height`  | `number` | Image height for all images declared in the `image` object (in `px`).   | `undefined`   |
-| `preload`  | `boolean` | Preloads the first image in a list, which helps prioritizing the display of images over other assets | `false`   |
+| Prop name                           | Type      | Description                                                                                                           | Default value |
+| ----------------------------------- | --------- | --------------------------------------------------------------------------------------------------------------------- | ------------- |
+| `images`                            | `array`   | Array of objects declaring all desired images to be rendered.                                                         | `undefined`   |
+| `height`                            | `number`  | Image height for all images declared in the `image` object (in `px`).                                                 | `undefined`   |
+| `preload`                           | `boolean` | Preloads the first image in a list, which helps prioritizing the display of images over other assets                  | `false`       |
+| `experimentalSetExplicitDimensions` | `boolean` | Sets explicit `width` and/or `height` attributes on each image, if `width` and/or `height` props are provided in `px` |
 
 ### `image-list` props
 
-| Prop name | Type     | Description                                                   | Default value |
-| --------- | -------- | ------------------------------------------------------------- | ------------- |
-| `images`  | `array`  | Array of objects declaring all desired images to be rendered. | `undefined`   |
-| `height`  | `number` | Image height for all images declared in the `image` object (in `px`).   | `undefined`   |
+| Prop name | Type     | Description                                                           | Default value |
+| --------- | -------- | --------------------------------------------------------------------- | ------------- |
+| `images`  | `array`  | Array of objects declaring all desired images to be rendered.         | `undefined`   |
+| `height`  | `number` | Image height for all images declared in the `image` object (in `px`). | `undefined`   |
 
 - **`images` array:**
 
-| Prop name     | Type     | Description                               | Default value |
-| ------------- | -------- | ----------------------------------------- | ------------- |
-| `image`       | `string` | Image URL.                                | `undefined`   |
-| `mobileImage` | `string` | Mobile image URL.                         | `undefined`   |
-| `description` | `string` | Image description.                        | `undefined`   |
-| `link`        | `object` | Links an URL to the image being rendered. | `undefined`   |
-| `width` | `string` / `number` | Image width (in `%` or `px`). | `100%` |
+| Prop name     | Type                | Description                               | Default value |
+| ------------- | ------------------- | ----------------------------------------- | ------------- |
+| `image`       | `string`            | Image URL.                                | `undefined`   |
+| `mobileImage` | `string`            | Mobile image URL.                         | `undefined`   |
+| `description` | `string`            | Image description.                        | `undefined`   |
+| `link`        | `object`            | Links an URL to the image being rendered. | `undefined`   |
+| `width`       | `string` / `number` | Image width (in `%` or `px`).             | `100%`        |
 
 - **`link` object:**
 

--- a/react/Image.tsx
+++ b/react/Image.tsx
@@ -117,6 +117,11 @@ function Image(props: ImageProps) {
 
   const placeholderSize = height ?? minHeight ?? maxHeight ?? 'auto'
 
+  const widthWithoutUnits = width ? width.toString().replace(/\D/g, '') : null
+  const heightWithoutUnits = height
+    ? height.toString().replace(/\D/g, '')
+    : null
+
   const formattedSrc = formatIOMessage({ id: src, intl })
   const formattedAlt = formatIOMessage({ id: alt, intl })
 
@@ -130,10 +135,13 @@ function Image(props: ImageProps) {
       style={imageDimensions}
       ref={imageRef}
       className={handles.imageElement}
-      {...(experimentalSetExplicitDimensions
+      {...(experimentalSetExplicitDimensions &&
+      !width?.toString().includes('%') &&
+      !height?.toString().includes('%') &&
+      (widthWithoutUnits || heightWithoutUnits)
         ? {
-            width,
-            height,
+            width: widthWithoutUnits ?? undefined,
+            height: heightWithoutUnits ?? undefined,
           }
         : {})}
       {...(preload

--- a/react/Image.tsx
+++ b/react/Image.tsx
@@ -122,6 +122,11 @@ function Image(props: ImageProps) {
     ? height.toString().replace(/\D/g, '')
     : null
 
+  const explicitDimensionsAreAvailable =
+    !width?.toString().includes('%') &&
+    !height?.toString().includes('%') &&
+    (widthWithoutUnits || heightWithoutUnits)
+
   const formattedSrc = formatIOMessage({ id: src, intl })
   const formattedAlt = formatIOMessage({ id: alt, intl })
 
@@ -135,10 +140,7 @@ function Image(props: ImageProps) {
       style={imageDimensions}
       ref={imageRef}
       className={handles.imageElement}
-      {...(experimentalSetExplicitDimensions &&
-      !width?.toString().includes('%') &&
-      !height?.toString().includes('%') &&
-      (widthWithoutUnits || heightWithoutUnits)
+      {...(experimentalSetExplicitDimensions && explicitDimensionsAreAvailable
         ? {
             width: widthWithoutUnits ?? undefined,
             height: heightWithoutUnits ?? undefined,

--- a/react/Image.tsx
+++ b/react/Image.tsx
@@ -21,6 +21,7 @@ export interface ImageProps
   minHeight?: string | number
   blockClass?: string
   experimentalPreventLayoutShift?: boolean
+  experimentalSetExplicitDimensions?: boolean
   classes?: CssHandlesTypes.CustomClasses<typeof CSS_HANDLES>
   preload?: boolean
   /**
@@ -83,6 +84,7 @@ function Image(props: ImageProps) {
     link,
     title,
     experimentalPreventLayoutShift,
+    experimentalSetExplicitDimensions,
     analyticsProperties = 'none',
     promotionId,
     promotionName,
@@ -128,6 +130,12 @@ function Image(props: ImageProps) {
       style={imageDimensions}
       ref={imageRef}
       className={handles.imageElement}
+      {...(experimentalSetExplicitDimensions
+        ? {
+            width,
+            height,
+          }
+        : {})}
       {...(preload
         ? {
             'data-vtex-preload': 'true',

--- a/react/ImageList.tsx
+++ b/react/ImageList.tsx
@@ -12,6 +12,7 @@ export interface ImageListProps {
   height?: number
   preload?: boolean
   experimentalPreventLayoutShift?: boolean
+  experimentalSetExplicitDimensions?: boolean
 }
 
 function ImageList({
@@ -20,6 +21,7 @@ function ImageList({
   children,
   preload,
   experimentalPreventLayoutShift,
+  experimentalSetExplicitDimensions,
 }: PropsWithChildren<ImageListProps>) {
   const list = useListContext()?.list ?? []
   const { isMobile } = useDevice()
@@ -29,7 +31,8 @@ function ImageList({
     isMobile,
     height,
     preload,
-    experimentalPreventLayoutShift
+    experimentalPreventLayoutShift,
+    experimentalSetExplicitDimensions
   )
 
   const newListContextValue = list.concat(imageListContent)

--- a/react/ImageTypes.ts
+++ b/react/ImageTypes.ts
@@ -22,6 +22,7 @@ export type ImagesSchema = Array<{
   title?: string
   description: string
   experimentalPreventLayoutShift?: boolean
+  experimentalSetExplicitDimensions?: boolean
   width?: number | string
   analyticsProperties?: 'none' | 'provide'
   promotionId?: string

--- a/react/modules/imageAsList.tsx
+++ b/react/modules/imageAsList.tsx
@@ -8,7 +8,8 @@ export const getImagesAsJSXList = (
   isMobile: boolean,
   height: string | number,
   preload?: boolean,
-  experimentalPreventLayoutShift?: boolean
+  experimentalPreventLayoutShift?: boolean,
+  experimentalSetExplicitDimensions?: boolean
 ) => {
   return images.map(
     (
@@ -17,6 +18,7 @@ export const getImagesAsJSXList = (
         mobileImage,
         description,
         experimentalPreventLayoutShift: experimentalPreventLayoutShiftChild,
+        experimentalSetExplicitDimensions: experimentalSetExplicitDimensionsChild,
         width = '100%',
         ...props
       },
@@ -30,6 +32,10 @@ export const getImagesAsJSXList = (
         width={width}
         experimentalPreventLayoutShift={
           experimentalPreventLayoutShift ?? experimentalPreventLayoutShiftChild
+        }
+        experimentalSetExplicitDimensions={
+          experimentalSetExplicitDimensions ??
+          experimentalSetExplicitDimensionsChild
         }
         preload={preload && idx === 0}
         {...props}


### PR DESCRIPTION
#### What problem is this solving?

Current code does not allow explicit width and height properties to be set on `img` elements. This PR adds a new `experimentalSetExplicitDimensions` prop which, when set to `true`, will apply the specified `width` and `height` to the `img` tag. The intention is to allow stores to improve their Cumulative Layout Shift score.

#### How to test it?

Linked in this workspace: http://arthur--eriksbikeshop.myvtex.com/
(inspect the 6 category images near the top of the homepage)