### PR TITLE
feat: spread remaining props to img tag

### DIFF
--- a/docs/README.md
+++ b/docs/README.md
@@ -85,6 +85,8 @@ Note that the `slider-layout` block, exported from the Slider Layout app, is giv
 | `link`        | `object`            | Links an URL to the image being rendered. | `undefined`   |
 | `width`       | `string` / `number` | Image width (in `%` or `px`).             | `100%`        |
 
+> They can also receive any image HTML attribute.
+
 - **`link` object:**
 
 | Prop name    | Type      | Description                                                                                                                                                                     | Default value |

--- a/react/Image.tsx
+++ b/react/Image.tsx
@@ -93,6 +93,7 @@ function Image(props: ImageProps) {
     preload,
     // eslint-disable-next-line
     __isDuplicated,
+    ...rest
   } = props
 
   const imageRef = useRef<HTMLImageElement | null>(null)
@@ -151,6 +152,7 @@ function Image(props: ImageProps) {
             'data-vtex-preload': 'true',
           }
         : {})}
+      {...rest}
     />
   )
 


### PR DESCRIPTION
#### What problem is this solving?

Some important HTML attributes might be ignored. This PR makes sure the remaining properties are getting passed to the `img` tag.